### PR TITLE
Add app size constants for consistent UI sizing

### DIFF
--- a/lib/core/utils/constants/sizes.dart
+++ b/lib/core/utils/constants/sizes.dart
@@ -1,0 +1,71 @@
+class AppSizes {
+  // padding and margin sizes
+
+  static const double xs = 4.0;
+  static const double sm = 8.0;
+  static const double md = 16.0;
+  static const double lg = 24.0;
+  static const double xl = 32.0;
+
+  // Icons sizes
+
+  static const double iconXs = 12.0;
+  static const double iconSm = 16.0;
+  static const double iconMd = 24.0;
+  static const double iconLg = 32.0;
+
+  // Font sizes
+  static const double fontSizeSm = 14.0;
+  static const double fontSizeMd = 16.0;
+  static const double fontSizeLg = 18.0;
+
+  // Button sizes
+  static const double buttonHeight = 18.0;
+  static const double buttonRadius = 12.0;
+  static const double buttonWidth = 120.0;
+
+  //App Bar height
+  static const double appBarHeight = 56.0;
+
+  // image sizes
+  static const double imageThumbSize = 80;
+
+  // default spactin between sctions
+  static const double defaultSpace = 20;
+  static const double spaceBtwItems = 16;
+  static const double spaceBtwSections = 32;
+
+  // Border radius
+  static const double borderRediusSm = 4;
+  static const double borderRediusMd = 8;
+  static const double borderRediusLg = 12;
+
+  // divider height
+
+  static const double dividerHeight = 1;
+
+  // Product item dimensions
+  static const double productImageSize = 120;
+  static const double productImageRadius = 16;
+  static const double productItemHeight = 160;
+
+  // input field
+  static const double inputFieldRadius = 12;
+  static const double spaceBtwInputField = 16;
+
+  // card sizes
+  static const double cardRadiusLg = 16;
+  static const double cardRadiusMd = 12;
+  static const double cardRadiusSm = 10;
+  static const double cardRadiusXs = 6;
+  static const double cardElevation = 2;
+
+  // image carousel height
+  static const double imageCarouseHeight = 200;
+
+  // Loading indicator Size
+  static const double loadingIndicatorSize = 36;
+
+  // Grid vie spacing
+  static const double gridViewSpacing = 16;
+}


### PR DESCRIPTION
This pull request introduces a new `AppSizes` class in the `lib/core/utils/constants/sizes.dart` file to centralize and standardize various size constants used throughout the application. This change helps improve maintainability and consistency.

Key changes include:

* Addition of padding and margin sizes, including `xs`, `sm`, `md`, `lg`, and `xl`.
* Definition of icon sizes, such as `iconXs`, `iconSm`, `iconMd`, and `iconLg`.
* Standardization of font sizes, including `fontSizeSm`, `fontSizeMd`, and `fontSizeLg`.
* Specification of button dimensions, such as `buttonHeight`, `buttonRadius`, and `buttonWidth`.
* Inclusion of various other size constants for elements like app bar height, image sizes, spacing, border radius, divider height, product item dimensions, input fields, cards, image carousel height, loading indicator size, and grid view spacing.